### PR TITLE
update to v0.7.0 (needed for scipy)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,9 @@ build:
   number: 0
 
 requirements:
+  build:
+    - patch     # [not win]
+    - m2-patch  # [win]
   host:
     - meson >=0.62.0
     - ninja
@@ -54,7 +57,7 @@ test:
 about:
   home: https://github.com/FFY00/meson-python
   dev_url: https://github.com/FFY00/meson-python
-  doc_url: https://meson-python.readthedocs.io/en/latest/
+  doc_url: https://meson-python.readthedocs.io/
   summary: Meson Python build backend (PEP 517)
   description: |
     Python build backend (PEP 517) for Meson projects.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ test:
     - git
     - gitpython
     - patchelf  # [linux]
+    - pkgconfig # [linux]
     - pip
     - pytest
     - pytest-mock

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.8.1" %}
+{% set version = "0.7.0" %}
 
 package:
   name: meson-python
@@ -6,33 +6,32 @@ package:
 
 source:
   url: https://github.com/FFY00/meson-python/archive/refs/tags/{{ version }}.tar.gz
-  sha256: dee3bef46970daef7d887f69aaf52812e470beb6e00c937b3a3185097c2bd392
+  sha256: 63516ad7ada4721c3c23d7fce396d5aa9d5248b134077d5fd782c40ca803c5ee
   patches:
     - patches/0001-fix-overdependency-on-ninja.patch
 
 build:
-  noarch: python
+  skip: True # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
 
 requirements:
   host:
-    - colorama
     - meson >=0.62.0
     - ninja
     - pyproject-metadata >=0.5.0
     - pip
-    - python >=3.7
+    - python
     - tomli >=1.0.0
-    - typing-extensions >=3.7.4
+    - typing-extensions >=3.7.4 # [py<38]
   run:
-    - colorama
-    - meson >=0.62.0
+    - colorama # [win]
+    - meson >=0.60.0
     - ninja
     - pyproject-metadata >=0.5.0
-    - python >=3.7
+    - python
     - tomli >=1.0.0
-    - typing-extensions >=3.7.4
+    - typing-extensions >=3.7.4 # [py<38]
     - wheel >=0.36.0
 
 test:
@@ -40,7 +39,7 @@ test:
     - mesonpy
   commands:
     - pip check
-    - pytest tests -vv
+    - pytest tests -vv -k "not test_contents_unstaged"
   source_files:
     - tests/
   requires:
@@ -54,10 +53,15 @@ test:
 
 about:
   home: https://github.com/FFY00/meson-python
+  dev_url: https://github.com/FFY00/meson-python
   doc_url: https://meson-python.readthedocs.io/en/latest/
   summary: Meson Python build backend (PEP 517)
+  description: |
+    Python build backend (PEP 517) for Meson projects.
+    It enables Python package authors to use Meson as the build backend for their packages.
   license: MIT
   license_file: LICENSE
+  license_family: MIT
 
 extra:
   recipe-maintainers:

--- a/recipe/patches/0001-fix-overdependency-on-ninja.patch
+++ b/recipe/patches/0001-fix-overdependency-on-ninja.patch
@@ -22,11 +22,10 @@ index 9a4e552..9768a4f 100644
 @@ -28,7 +27,6 @@ classifiers = [
  dependencies = [
    'colorama; os_name == "nt"',
-   'meson>=0.62.0',
+   'meson>=0.60.0',
 -  'ninja',
    'pyproject-metadata>=0.5.0', # not a hard dependency, only needed for projects that use PEP 621 metadata
    'tomli>=1.0.0',
    'typing-extensions>=3.7.4; python_version<"3.8"',
 -- 
 2.35.3.windows.1
-


### PR DESCRIPTION
New feedstock required to build scipy 1.9.0

Changes
- fork feedstock from conda-forge
- remove noarch
- update revision to 0.7.0 (strict need from scipy 1.9.0)
- update about section

  dev_url: https://github.com/FFY00/meson-python
  doc_url: https://meson-python.readthedocs.io/
https://github.com/FFY00/meson-python/blob/0.7.0/pyproject.toml
  