### PR TITLE
[PKG-2247] meson-python 0.13.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,17 +17,15 @@ build:
 requirements:
   host:
     - meson 1.0.1
-    - ninja-base 1.10.2
     - pip
     - pyproject-metadata 0.7.1
     - python
     - setuptools
     - tomli 1.2.2  # [py<311]
-    - wheel
+    # mesonpy takes care of creating the wheels without using wheel. See https://github.com/mesonbuild/meson-python/blob/main/mesonpy/_wheelfile.py
   run:
     - colorama # [win]
     - meson >=0.63.3
-    - ninja-base
     - pyproject-metadata >=0.7.1
     - python
     # about setuptools see https://github.com/mesonbuild/meson-python/pull/308

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.12.1" %}
+{% set version = "0.13.1" %}
 {% set name = "meson-python" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/meson_python-{{ version }}.tar.gz
-  sha256: 3d5b3e581d70a58a97b9c116a75e97a76cc4b4c7e75fa0658fc8392371e2f2c2
+  sha256: 63b3170001425c42fa4cfedadb9051cbd28925ff8eed7c40d36ba0099e3c7618
 
 build:
   skip: True # [py<37]
@@ -15,47 +15,49 @@ build:
   number: 0
 
 requirements:
-  build:
-    - patch     # [not win]
-    - m2-patch  # [win]
   host:
-    - meson >=0.63.3
-    - ninja
+    - meson 1.0.1
+    - ninja-base 1.10.2
     - pip
-    - wheel
-    - setuptools
+    - pyproject-metadata 0.7.1
     - python
-    - pyproject-metadata >=0.6.1
-    - tomli >=1.0.0  # [py<311]
-    - typing-extensions >=3.7.4  # [py<310]
+    - setuptools
+    - tomli 1.2.2  # [py<311]
+    - wheel
   run:
     - colorama # [win]
     - meson >=0.63.3
-    - ninja
-    - pyproject-metadata >=0.6.1
+    - ninja-base
+    - pyproject-metadata >=0.7.1
     - python
+    # about setuptools see https://github.com/mesonbuild/meson-python/pull/308
+    - setuptools >=60.0  # [py>=312]
     - tomli >=1.0.0
-    - typing-extensions >=3.7.4 # [py<310]
 
 test:
   imports:
     - mesonpy
-  commands:
-    - pip check
-    - pytest tests -vv -k "not (test_contents_unstaged or test_wheel.py or test_pep518 or test_tag or test_detect_wheel_tag or test_spam)" # tests are relevant to wheel and not conda packages
   source_files:
     - tests/
     - docs/
+    - pyproject.toml
   requires:
     - {{ compiler('c') }}
+    # cython required for Python 3.12 support, see https://github.com/mesonbuild/meson-python/commit/936eee3fddfda34cbbb690acec8a170d089c1770
+    - cython >=0.29.34
     - git
     - gitpython
-    - patchelf  # [linux]
-    - pkgconfig # [linux]
+    - patchelf   # [linux]
+    - pkgconfig  # [linux]
     - pip
     - pytest
     - pytest-mock
-    - pyproject-metadata
+    # see https://github.com/mesonbuild/meson-python/commit/424f2f97e00c5281437355acd1232d29431dcf23
+    - typing-extensions >=3.7.4  # [py<310]
+  commands:
+    - pip check
+    - pytest tests -vv -k "not (test_contents_unstaged or test_wheel.py or test_pep518 or test_tag or test_detect_wheel_tag or test_spam)" # tests are relevant to wheel and not conda packages
+
 about:
   home: https://github.com/mesonbuild/meson-python
   dev_url: https://github.com/mesonbuild/meson-python
@@ -72,3 +74,6 @@ extra:
   recipe-maintainers:
     - awvwgk
     - rgommers
+  skip-lints:
+    - python_build_tool_in_run
+    - build_tools_must_be_in_build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,3 +75,4 @@ extra:
   skip-lints:
     - python_build_tool_in_run
     - build_tools_must_be_in_build
+    - missing_wheel


### PR DESCRIPTION
Changelog: https://github.com/mesonbuild/meson-python/blob/0.13.1/CHANGELOG.rst
License: https://github.com/mesonbuild/meson-python/blob/0.13.1/LICENSE
Requirements: https://github.com/mesonbuild/meson-python/blob/0.13.1/pyproject.toml

Actions:
1. Remove `build` with `patch` an `m2-patch`
2. Add strong pinnings and update dependencies in `host`, also remove `wheel`, see https://github.com/mesonbuild/meson-python/blob/main/mesonpy/_wheelfile.py
3. Update `run` dependencies
4. Reorder `run` dependencies
5. Add `pyproject.toml` to `source_files`
6. `cython` is required for Python 3.12 support in `tests`
7. Move `typing-extensions >=3.7.4  # [py<310]` from run to `test/requires`
8. Skip lints
