### PR TITLE
V0.15.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,4 @@
 aggregate_branch: 3.12
+
+channels:
+- https://staging.continuum.io/prefect/fs/meson-feedstock/pr18/8d59b5b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
 aggregate_branch: 3.12
 
 channels:
-- https://staging.continuum.io/prefect/fs/meson-feedstock/pr18/8d59b5b
+  - https://staging.continuum.io/prefect/fs/meson-feedstock/pr18/8d59b5b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,1 @@
 aggregate_branch: 3.12
-
-channels:
-  - https://staging.continuum.io/prefect/fs/meson-feedstock/pr18/8d59b5b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ test:
     # CPPFLAGS exports -DNDEBUG which is unwanted
     - export CPPFLAGS=${CPPFLAGS//-DNDEBUG/}
     # tests are relevant to wheel and not conda packages
-    - pytest tests -vv -k "not (test_tags.py or test_wheel.py)"
+    - pytest tests -vv -k "not (test_contents_unstaged or test_wheel.py or test_pep518 or test_tag or test_detect_wheel_tag or test_spam)" # tests are relevant to wheel and not conda packages
 
 about:
   home: https://github.com/mesonbuild/meson-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,6 +56,8 @@ test:
   commands:
     - pip check
     - pytest tests -vv -k "not (test_contents_unstaged or test_wheel.py or test_pep518 or test_tag or test_detect_wheel_tag or test_spam)" # tests are relevant to wheel and not conda packages
+    # CPPFLAGS exports -DNDEBUG which is unwanted
+    - export CPPFLAGS=${CPPFLAGS//-DNDEBUG/}
 
 about:
   home: https://github.com/mesonbuild/meson-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,8 +59,8 @@ test:
     # CPPFLAGS exports -DNDEBUG which is unwanted
     - export CPPFLAGS=${CPPFLAGS//-DNDEBUG/}  # [unix]
     # tests are relevant to wheel and not conda packages
-    - pytest tests -vv -k "not (test_tags.py or test_wheel.py)" # tests are relevant to wheel and not conda packages
-
+    - pytest tests -vv -k "not (test_tags.py or test_wheel.py)"  # [unix]
+    - pytest tests --basetemp=./tmp/meson-python-test/ -vv -k "not (test_tags.py or test_wheel.py)"  # [win]
 about:
   home: https://github.com/mesonbuild/meson-python
   dev_url: https://github.com/mesonbuild/meson-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,7 +60,8 @@ test:
     - export CPPFLAGS=${CPPFLAGS//-DNDEBUG/}  # [unix]
     # tests are relevant to wheel and not conda packages
     - pytest tests -vv -k "not (test_tags.py or test_wheel.py)"  # [unix]
-    - pytest tests --basetemp=./tmp/meson-python-test/ -vv -k "not (test_tags.py or test_wheel.py)"  # [win]
+    - pytest tests -vv -k "not (test_tags.py or test_wheel.py or test_editable_install or test_editble_reentrant or test_spam)"  # [win]
+
 about:
   home: https://github.com/mesonbuild/meson-python
   dev_url: https://github.com/mesonbuild/meson-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ test:
     # CPPFLAGS exports -DNDEBUG which is unwanted
     - export CPPFLAGS=${CPPFLAGS//-DNDEBUG/}  # [unix]
     # tests are relevant to wheel and not conda packages
-    - pytest tests -vv -k "not (test_mesonpy_meta_finder or test_editble_reentrant or test_spam)" # tests are relevant to wheel and not conda packages
+    - pytest tests -vv -k "not (test_tags.py or test_wheel.py or test_mesonpy_meta_finder or test_editble_reentrant or test_spam)" # tests are relevant to wheel and not conda packages
 
 about:
   home: https://github.com/mesonbuild/meson-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,8 +55,6 @@ test:
     - typing-extensions >=3.7.4  # [py<310]
   commands:
     - pip check
-    # CPPFLAGS exports -DNDEBUG which is unwanted
-    - export CPPFLAGS=${CPPFLAGS//-DNDEBUG/}
     # tests are relevant to wheel and not conda packages
     - pytest tests -vv -k "not (test_contents_unstaged or test_wheel.py or test_pep518 or test_tag or test_detect_wheel_tag or test_spam)" # tests are relevant to wheel and not conda packages
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,9 @@ test:
     - typing-extensions >=3.7.4  # [py<310]
   commands:
     - pip check
+    # CPPFLAGS exports -DNDEBUG which is unwanted
+    - export CPPFLAGS=${CPPFLAGS//-DNDEBUG/}  # [unix]
+    - set CPPFLAGS=${CPPFLAGS//-DNDEBUG/}  # [win]
     # tests are relevant to wheel and not conda packages
     - pytest tests -vv -k "not (test_contents_unstaged or test_wheel.py or test_pep518 or test_tag or test_detect_wheel_tag or test_spam)" # tests are relevant to wheel and not conda packages
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,8 @@ test:
     - pip check
     # CPPFLAGS exports -DNDEBUG which is unwanted
     - export CPPFLAGS=${CPPFLAGS//-DNDEBUG/}
-    - pytest tests -vv -k "not (test_contents_unstaged or test_wheel.py or test_pep518 or test_tag or test_detect_wheel_tag or test_spam)" # tests are relevant to wheel and not conda packages
+    # tests are relevant to wheel and not conda packages
+    - pytest tests -vv -k "not (test_tags.py or test_wheel.py)"
 
 about:
   home: https://github.com/mesonbuild/meson-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     # mesonpy takes care of creating the wheels without using wheel. See https://github.com/mesonbuild/meson-python/blob/main/mesonpy/_wheelfile.py
   run:
     - colorama # [win]
+    # Tests fail when using meson >1.2 on Python 3.8 which could affect other packages.
     - meson 1.2  # [py<=38]
     - meson >=0.63.3 # [py<312]
     - meson >=1.2.3 # [py>=312]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.13.1" %}
+{% set version = "0.15.0" %}
 {% set name = "meson-python" %}
 
 package:
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/meson_python-{{ version }}.tar.gz
-  sha256: 63b3170001425c42fa4cfedadb9051cbd28925ff8eed7c40d36ba0099e3c7618
+  sha256: fddb73eecd49e89c1c41c87937cd89c2d0b65a1c63ba28238681d4bd9484d26f
 
 build:
   skip: True # [py<37]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation 
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,9 +58,8 @@ test:
     - pip check
     # CPPFLAGS exports -DNDEBUG which is unwanted
     - export CPPFLAGS=${CPPFLAGS//-DNDEBUG/}  # [unix]
-    - set CPPFLAGS=${CPPFLAGS//-DNDEBUG/}  # [win]
     # tests are relevant to wheel and not conda packages
-    - pytest tests -vv -k "not (test_contents_unstaged or test_wheel.py or test_pep518 or test_tag or test_detect_wheel_tag or test_spam)" # tests are relevant to wheel and not conda packages
+    - pytest tests -vv -k "not (test_mesonpy_meta_finder or test_editble_reentrant or test_spam)" # tests are relevant to wheel and not conda packages
 
 about:
   home: https://github.com/mesonbuild/meson-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     # mesonpy takes care of creating the wheels without using wheel. See https://github.com/mesonbuild/meson-python/blob/main/mesonpy/_wheelfile.py
   run:
     - colorama # [win]
+    - meson 1.2  # [py<=38]
     - meson >=0.63.3 # [py<312]
     - meson >=1.2.3 # [py>=312]
     - pyproject-metadata >=0.7.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ test:
     # CPPFLAGS exports -DNDEBUG which is unwanted
     - export CPPFLAGS=${CPPFLAGS//-DNDEBUG/}  # [unix]
     # tests are relevant to wheel and not conda packages
-    - pytest tests -vv -k "not (test_editable_install or test_tags.py or test_wheel.py or test_mesonpy_meta_finder or test_editble_reentrant or test_spam)" # tests are relevant to wheel and not conda packages
+    - pytest tests -vv -k "not (test_tags.py or test_wheel.py)" # tests are relevant to wheel and not conda packages
 
 about:
   home: https://github.com/mesonbuild/meson-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,12 +25,13 @@ requirements:
     # mesonpy takes care of creating the wheels without using wheel. See https://github.com/mesonbuild/meson-python/blob/main/mesonpy/_wheelfile.py
   run:
     - colorama # [win]
-    - meson >=0.63.3
+    - meson >=0.63.3 # [py<312]
+    - meson >=1.2.3 # [py>=312]
     - pyproject-metadata >=0.7.1
     - python
     # about setuptools see https://github.com/mesonbuild/meson-python/pull/308
     - setuptools >=60.0  # [py>=312]
-    - tomli >=1.0.0
+    - tomli >=1.0.0 # [py<311]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ test:
     # CPPFLAGS exports -DNDEBUG which is unwanted
     - export CPPFLAGS=${CPPFLAGS//-DNDEBUG/}  # [unix]
     # tests are relevant to wheel and not conda packages
-    - pytest tests -vv -k "not (test_tags.py or test_wheel.py or test_mesonpy_meta_finder or test_editble_reentrant or test_spam)" # tests are relevant to wheel and not conda packages
+    - pytest tests -vv -k "not (test_editable_install or test_tags.py or test_wheel.py or test_mesonpy_meta_finder or test_editble_reentrant or test_spam)" # tests are relevant to wheel and not conda packages
 
 about:
   home: https://github.com/mesonbuild/meson-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ test:
   requires:
     - {{ compiler('c') }}
     # cython required for Python 3.12 support, see https://github.com/mesonbuild/meson-python/commit/936eee3fddfda34cbbb690acec8a170d089c1770
-    - cython >=0.29.34
+    - cython >=3.0.3
     - git
     - gitpython
     - patchelf   # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,9 +55,9 @@ test:
     - typing-extensions >=3.7.4  # [py<310]
   commands:
     - pip check
-    - pytest tests -vv -k "not (test_contents_unstaged or test_wheel.py or test_pep518 or test_tag or test_detect_wheel_tag or test_spam)" # tests are relevant to wheel and not conda packages
     # CPPFLAGS exports -DNDEBUG which is unwanted
     - export CPPFLAGS=${CPPFLAGS//-DNDEBUG/}
+    - pytest tests -vv -k "not (test_contents_unstaged or test_wheel.py or test_pep518 or test_tag or test_detect_wheel_tag or test_spam)" # tests are relevant to wheel and not conda packages
 
 about:
   home: https://github.com/mesonbuild/meson-python


### PR DESCRIPTION
meson-python 0.15.0

**Destination channel:** defaults

### Links

- [PKG-4031](https://anaconda.atlassian.net/browse/PKG-4031)
- [Upstream repository](https://github.com/mesonbuild/meson-python/tree/0.15.0)
- [Upstream changelog/diff](https://github.com/mesonbuild/meson-python/blob/0.15.0/CHANGELOG.rst)
- Relevant dependency PRs:
  - [PKG-4012](https://anaconda.atlassian.net/browse/PKG-4012)

### Explanation of changes:

- Update version and dependencies
- Add `abs.yaml` for 3.12 build
- Add `-DNDEBUG` fix
- Test updates


[PKG-4031]: https://anaconda.atlassian.net/browse/PKG-4031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-4012]: https://anaconda.atlassian.net/browse/PKG-4012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ