### PR TITLE
meson-python 0.16.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,11 +49,15 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_archflags_envvar_parsing" %} # [osx and x86_64]
 
 # The following fail: assert 'macosx_10_9_x86_64' == 'macosx_10_16_x86_64'
-{% set tests_to_skip = tests_to_skip + " or test_scipy_like" %}               # [osx and x86_64]
-{% set tests_to_skip = tests_to_skip + " or test_detect_wheel_tag_module" %}  # [osx and x86_64]
-{% set tests_to_skip = tests_to_skip + " or test_detect_wheel_tag_script" %}  # [osx and x86_64]
-{% set tests_to_skip = tests_to_skip + " or test_limited_api" %}              # [osx and x86_64]
-{% set tests_to_skip = tests_to_skip + " or test_limited_api_disabled" %}     # [osx and x86_64]
+# (or _arm64 on the builders -- it works locally)
+{% set tests_to_skip = tests_to_skip + " or test_scipy_like" %}               # [osx]
+{% set tests_to_skip = tests_to_skip + " or test_detect_wheel_tag_module" %}  # [osx]
+{% set tests_to_skip = tests_to_skip + " or test_detect_wheel_tag_script" %}  # [osx]
+{% set tests_to_skip = tests_to_skip + " or test_limited_api" %}              # [osx]
+{% set tests_to_skip = tests_to_skip + " or test_limited_api_disabled" %}     # [osx]
+
+# Gets a SIGKILL on the builders
+{% set tests_to_skip = tests_to_skip + " or test_local_lib" %}                # [osx and arm64]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,7 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_limited_api_disabled" %}     # [osx]
 
 # Gets a SIGKILL on the builders
+{% set tests_to_skip = tests_to_skip + " or test_archflags_envvar" %}         # [osx and x86_64]
 {% set tests_to_skip = tests_to_skip + " or test_local_lib" %}                # [osx and arm64]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     # wheel. See
     # https://github.com/mesonbuild/meson-python/blob/main/mesonpy/_wheelfile.py
   run:
-    - colorama          # [win]
     # Tests fail when using meson >1.2 on Python 3.8 which could
     # affect other packages.  True on osx-arm64 at least.
     - meson 1.2         # [py<=38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,15 @@ requirements:
     - setuptools >=60.0 # [py>=312]
     - tomli >=1.0.0     # [py<311]
 
+{% set tests_to_skip = "" %}
+{% set tests_to_skip = tests_to_skip + "test_tags.py" %}                      # [unix or win]
+{% set tests_to_skip = tests_to_skip + " or test_wheel.py" %}                 # [win]
+{% set tests_to_skip = tests_to_skip + " or test_editable_install" %}         # [win]
+{% set tests_to_skip = tests_to_skip + " or test_editble_reentrant" %}        # [win]
+{% set tests_to_skip = tests_to_skip + " or test_editable_verbose" %}         # [win]
+{% set tests_to_skip = tests_to_skip + " or test_archflags_envvar_parsing" %} # [osx-64]
+{% set tests_to_skip = tests_to_skip + " or test_spam" %}                     # [unix or win]
+
 test:
   imports:
     - mesonpy
@@ -65,8 +74,7 @@ test:
     # CPPFLAGS exports -DNDEBUG which is unwanted
     - export CPPFLAGS=${CPPFLAGS//-DNDEBUG/}  # [unix]
     # tests are relevant to wheel and not conda packages
-    - pytest tests -vv -k "not (test_tags.py or test_wheel.py)"  # [unix]
-    - pytest tests -vv -k "not (test_tags.py or test_wheel.py or test_editable_install or test_editble_reentrant or test_editable_verbose or test_spam)"  # [win]
+    - pytest tests -vv -k "not ({{ tests_to_skip }})"
 
 about:
   home: https://github.com/mesonbuild/meson-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,27 +16,25 @@ build:
 
 requirements:
   host:
-    - meson 1.0.1
+    - meson >=0.63.3    # [py<312]
+    - meson >=1.2.3     # [py>=312]
     - pip
-    - pyproject-metadata 0.7.1
+    - pyproject-metadata
     - python
     - setuptools
-    - tomli 1.2.2       # [py<311]
+    - tomli             # [py<311]
     # mesonpy takes care of creating the wheels without using
     # wheel. See
     # https://github.com/mesonbuild/meson-python/blob/main/mesonpy/_wheelfile.py
   run:
-    # Tests fail when using meson >1.2 on Python 3.8 which could
-    # affect other packages.  True on osx-arm64 at least.
+    # meson >1.2 on py38 (on at least osx-arm64) will generate a SEGV
+    # during tests.  Verified on 0.16.0.
     - meson 1.2         # [py<=38]
     - meson >=0.63.3    # [py<312]
     - meson >=1.2.3     # [py>=312]
     - packaging >=19.0
     - pyproject-metadata >=0.7.1
     - python
-    # about setuptools see
-    # https://github.com/mesonbuild/meson-python/pull/308
-    - setuptools >=60.0 # [py>=312]
     - tomli >=1.0.0     # [py<311]
 
 {% set tests_to_skip = "" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.15.0" %}
+{% set version = "0.16.0" %}
 {% set name = "meson-python" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/meson_python-{{ version }}.tar.gz
-  sha256: fddb73eecd49e89c1c41c87937cd89c2d0b65a1c63ba28238681d4bd9484d26f
+  sha256: 9068c17e36c89d6c7ff709fffb2a8a9925e8cd0b02629728e5ceaf2ec505cb5f
 
 build:
   skip: True # [py<37]
@@ -21,19 +21,24 @@ requirements:
     - pyproject-metadata 0.7.1
     - python
     - setuptools
-    - tomli 1.2.2  # [py<311]
-    # mesonpy takes care of creating the wheels without using wheel. See https://github.com/mesonbuild/meson-python/blob/main/mesonpy/_wheelfile.py
+    - tomli 1.2.2       # [py<311]
+    # mesonpy takes care of creating the wheels without using
+    # wheel. See
+    # https://github.com/mesonbuild/meson-python/blob/main/mesonpy/_wheelfile.py
   run:
-    - colorama # [win]
-    # Tests fail when using meson >1.2 on Python 3.8 which could affect other packages.
-    - meson 1.2  # [py<=38]
-    - meson >=0.63.3 # [py<312]
-    - meson >=1.2.3 # [py>=312]
+    - colorama          # [win]
+    # Tests fail when using meson >1.2 on Python 3.8 which could
+    # affect other packages.  True on osx-arm64 at least.
+    - meson 1.2         # [py<=38]
+    - meson >=0.63.3    # [py<312]
+    - meson >=1.2.3     # [py>=312]
+    - packaging >=19.0
     - pyproject-metadata >=0.7.1
     - python
-    # about setuptools see https://github.com/mesonbuild/meson-python/pull/308
-    - setuptools >=60.0  # [py>=312]
-    - tomli >=1.0.0 # [py<311]
+    # about setuptools see
+    # https://github.com/mesonbuild/meson-python/pull/308
+    - setuptools >=60.0 # [py>=312]
+    - tomli >=1.0.0     # [py<311]
 
 test:
   imports:
@@ -44,7 +49,8 @@ test:
     - pyproject.toml
   requires:
     - {{ compiler('c') }}
-    # cython required for Python 3.12 support, see https://github.com/mesonbuild/meson-python/commit/936eee3fddfda34cbbb690acec8a170d089c1770
+    # cython required for Python 3.12 support, see
+    # https://github.com/mesonbuild/meson-python/commit/936eee3fddfda34cbbb690acec8a170d089c1770
     - cython >=3.0.3
     - git
     - gitpython
@@ -61,12 +67,12 @@ test:
     - export CPPFLAGS=${CPPFLAGS//-DNDEBUG/}  # [unix]
     # tests are relevant to wheel and not conda packages
     - pytest tests -vv -k "not (test_tags.py or test_wheel.py)"  # [unix]
-    - pytest tests -vv -k "not (test_tags.py or test_wheel.py or test_editable_install or test_editble_reentrant or test_spam)"  # [win]
+    - pytest tests -vv -k "not (test_tags.py or test_wheel.py or test_editable_install or test_editble_reentrant or test_editable_verbose or test_spam)"  # [win]
 
 about:
   home: https://github.com/mesonbuild/meson-python
   dev_url: https://github.com/mesonbuild/meson-python
-  doc_url: https://meson-python.readthedocs.io/
+  doc_url: https://mesonbuild.com/meson-python/
   summary: Meson Python build backend (PEP 517)
   description: |
     Python build backend (PEP 517) for Meson projects.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,8 +45,15 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_editable_install" %}         # [win]
 {% set tests_to_skip = tests_to_skip + " or test_editble_reentrant" %}        # [win]
 {% set tests_to_skip = tests_to_skip + " or test_editable_verbose" %}         # [win]
-{% set tests_to_skip = tests_to_skip + " or test_archflags_envvar_parsing" %} # [osx-64]
-{% set tests_to_skip = tests_to_skip + " or test_spam" %}                     # [unix or win]
+{% set tests_to_skip = tests_to_skip + " or test_spam" %}                     # [win]
+{% set tests_to_skip = tests_to_skip + " or test_archflags_envvar_parsing" %} # [osx and x86_64]
+
+# The following fail: assert 'macosx_10_9_x86_64' == 'macosx_10_16_x86_64'
+{% set tests_to_skip = tests_to_skip + " or test_scipy_like" %}               # [osx and x86_64]
+{% set tests_to_skip = tests_to_skip + " or test_detect_wheel_tag_module" %}  # [osx and x86_64]
+{% set tests_to_skip = tests_to_skip + " or test_detect_wheel_tag_script" %}  # [osx and x86_64]
+{% set tests_to_skip = tests_to_skip + " or test_limited_api" %}              # [osx and x86_64]
+{% set tests_to_skip = tests_to_skip + " or test_limited_api_disabled" %}     # [osx and x86_64]
 
 test:
   imports:


### PR DESCRIPTION
meson-python 0.16.0 

**Destination channel:** Defaults

### Links

- [PKG-5347]
- dev_url:        https://github.com/mesonbuild/meson-python/tree/0.16.0
- pypi:           https://pypi.org/project/meson-python/0.16.0
- pypi inspector: https://inspector.pypi.io/project/meson-python/0.16.0

### Explanation of changes:

- bump for `0.16.0`
  - add `packaging` as a run dependency
  - remove `colorama` as a `win` dependency
  - rework `build` and `run` to match `pyproject.toml` (had been missed in `0.15.0`)
  - change `doc_url`
- tests:
  - accidentally re-enabled `test_wheel.py` which works fine for most `unix` platforms
  - after lots of fiddling it seems the `osx` builders behave differently during tests
  - confirm `py38` `meson` upper bound (on `osx-arm64` at least)


[PKG-5347]: https://anaconda.atlassian.net/browse/PKG-5347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ