### PR TITLE
meson-python 0.17.1: Rebiuld for py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/pkgconfig-feedstock/pr7/337c401

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/pkgconfig-feedstock/pr7/337c401

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: True # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -86,6 +86,7 @@ test:
     - pytest-mock
     # see https://github.com/mesonbuild/meson-python/commit/424f2f97e00c5281437355acd1232d29431dcf23
     - typing-extensions >=3.7.4  # [py<311]
+    - wheel
   commands:
     - pip check
     # CPPFLAGS exports -DNDEBUG which is unwanted


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-10213](https://anaconda.atlassian.net/browse/PKG-10213)
- [Upstream repo](https://github.com/mesonbuild/meson-python/tree/0.17.1)
- requirements-tagged: https://github.com/mesonbuild/meson-python/blob/0.17.1/pyproject.toml


### Explanation of changes:

- Bump the build number to 1
- Add `ANACONDA_ROCKET_ENABLE_PY314 : yes` to `abs.yaml`

[PKG-10213]: https://anaconda.atlassian.net/browse/PKG-10213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ